### PR TITLE
putchar() and getchar() for newer SDCC

### DIFF
--- a/main.c
+++ b/main.c
@@ -75,8 +75,6 @@ void TIM1_UPD_OVF_TRG_BRK_IRQHandler(void) __interrupt(TIM1_UPD_OVF_TRG_BRK_IRQH
 int32_t map (int32_t x, int32_t in_min, int32_t in_max, int32_t out_min, int32_t out_max);
 
 void uart_init (void);
-void putchar(char c);
-char getchar(void);
 
 void adc_init (void);
 uint16_t adc_read_throttle (void);
@@ -480,15 +478,29 @@ void uart_init (void)
 	     UART2_MODE_TXRX_ENABLE);
 }
 
+// Since SDCC #9624, SDCC uses a standard-conforming putchar()-prototype.
+#if __SDCC_REVISION < 9624
 void putchar(char c)
 {
   //Write a character to the UART2
   UART2_SendData8(c);
 
   //Loop until the end of transmission
-  while (UART2_GetFlagStatus(UART2_FLAG_TXE) == RESET);
+  while(UART2_GetFlagStatus(UART2_FLAG_TXE) == RESET);
 }
+int putchar(int c)
+{
+  //Write a character to the UART2
+  UART2_SendData8(c);
 
+  //Loop until the end of transmission
+  while(UART2_GetFlagStatus(UART2_FLAG_TXE) == RESET);
+
+  return(c);
+}
+#endif
+
+// As of revision #9987 SDCC still has a non-compliant getchar()-prototype.
 char getchar(void)
 {
   uint8_t c = 0;

--- a/main.c
+++ b/main.c
@@ -478,7 +478,7 @@ void uart_init (void)
 	     UART2_MODE_TXRX_ENABLE);
 }
 
-// Since SDCC #9624, SDCC uses a standard-conforming putchar()-prototype.
+// Since revision #9624, SDCC uses a standard-conforming putchar()-prototype.
 #if __SDCC_REVISION < 9624
 void putchar(char c)
 {
@@ -500,8 +500,12 @@ int putchar(int c)
 }
 #endif
 
-// As of revision #9987 SDCC still has a non-compliant getchar()-prototype.
+// Since revision #9989, SDCC uses a standard-conforming getchar()-prototype.
+#if __SDCC_REVISION < 9989
 char getchar(void)
+#else
+int getchar(void)
+#endif
 {
   uint8_t c = 0;
 
@@ -512,7 +516,6 @@ char getchar(void)
 
   return (c);
 }
-
 
 int main (void)
 {


### PR DESCRIPTION
Current development versions (and the future SDCC 3.7.0) uses standard-compliant putchar() and getchar() prototypes.
The changes in main.c will make the code compile with all SDCC versions.

Philipp
